### PR TITLE
chore: add groups of dependencies to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,16 @@ updates:
       interval: 'weekly'
     commit-message:
       prefix: 'build'
+    groups:
+      typescript-eslint:
+        patterns:
+          - '@typescript-eslint/*'
+          - typescript-eslint
+      angular-eslint:
+        patterns:
+          - '@angular-eslint/*'
+          - angular-eslint
+      eslint:
+        patterns:
+          - '@eslint/*'
+          - eslint


### PR DESCRIPTION
add groups for:
- eslint
- angular-eslint
- typescript-eslint