### PR TITLE
feat: add optional boolean to enforce `erasableSyntaxOnly` flag in typescript options

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,12 +55,16 @@
   "peerDependencies": {
     "@prettier/plugin-xml": "^3.4.1",
     "eslint": "^9.20.0",
+    "eslint-plugin-erasable-syntax-only": "^0.2.1",
     "eslint-plugin-format": "^1.0.1",
     "eslint-plugin-tailwindcss": "^3.18.0",
     "prettier-plugin-slidev": "^1.0.5"
   },
   "peerDependenciesMeta": {
     "@prettier/plugin-xml": {
+      "optional": true
+    },
+    "eslint-plugin-erasable-syntax-only": {
       "optional": true
     },
     "eslint-plugin-format": {
@@ -127,6 +131,7 @@
     "changelogithub": "^13.12.1",
     "commitizen": "^4.3.1",
     "eslint": "^9.21.0",
+    "eslint-plugin-erasable-syntax-only": "^0.2.1",
     "eslint-plugin-format": "^1.0.1",
     "eslint-plugin-tailwindcss": "^3.18.0",
     "execa": "^9.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       eslint:
         specifier: ^9.21.0
         version: 9.21.0(jiti@2.4.2)
+      eslint-plugin-erasable-syntax-only:
+        specifier: ^0.2.1
+        version: 0.2.1(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       eslint-plugin-format:
         specifier: ^1.0.1
         version: 1.0.1(eslint@9.21.0(jiti@2.4.2))
@@ -1355,6 +1358,10 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  cached-factory@0.1.0:
+    resolution: {integrity: sha512-IGOSWu+NuED5UzCRmBeqQPZ8z7SkgrD/nN67W2iY1Qv83CVhevyMexkGclJ86saXisIqxoOnbeiTWvsCHRqJBw==}
+    engines: {node: '>=18'}
+
   cachedir@2.3.0:
     resolution: {integrity: sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==}
     engines: {node: '>=6'}
@@ -1827,6 +1834,14 @@ packages:
 
   eslint-parser-plain@0.1.1:
     resolution: {integrity: sha512-KRgd6wuxH4U8kczqPp+Oyk4irThIhHWxgFgLDtpgjUGVIS3wGrJntvZW/p6hHq1T4FOwnOtCNkvAI4Kr+mQ/Hw==}
+
+  eslint-plugin-erasable-syntax-only@0.2.1:
+    resolution: {integrity: sha512-rT/kAkgHvNmN0OTaCh2nRKHZ9afnsMqHfsou1Sdf7b63oprr1b2E9aKAZSdDea4TfSEGqqwj2+faJAgg3ha/wg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      '@typescript-eslint/parser': '>=8'
+      eslint: '>=9'
+      typescript: '>=5'
 
   eslint-plugin-format@1.0.1:
     resolution: {integrity: sha512-Tdns+CDjS+m7QrM85wwRi2yLae88XiWVdIOXjp9mDII0pmTBQlczPCmjpKnjiUIY3yPZNLqb5Ms/A/JXcBF2Dw==}
@@ -5023,6 +5038,8 @@ snapshots:
 
   cac@6.7.14: {}
 
+  cached-factory@0.1.0: {}
+
   cachedir@2.3.0: {}
 
   callsites@3.1.0: {}
@@ -5535,6 +5552,16 @@ snapshots:
       eslint: 9.21.0(jiti@2.4.2)
 
   eslint-parser-plain@0.1.1: {}
+
+  eslint-plugin-erasable-syntax-only@0.2.1(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3):
+    dependencies:
+      '@typescript-eslint/parser': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      cached-factory: 0.1.0
+      eslint: 9.21.0(jiti@2.4.2)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-format@1.0.1(eslint@9.21.0(jiti@2.4.2)):
     dependencies:

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -1,5 +1,10 @@
 import type { ConfigArray } from 'typescript-eslint';
-import type { OverridesOptions, StylisticOptions, TypeScriptParserOptions } from '../types';
+import type {
+  OverridesOptions,
+  StylisticOptions,
+  TypeScriptErasableSyntaxOnlyOptions,
+  TypeScriptParserOptions
+} from '../types';
 
 import process from 'node:process';
 
@@ -20,7 +25,7 @@ import namingConvention from './rules-configs/naming-convention';
  * @param options.overrides - Additional rule overrides.
  * @returns A ConfigArray containing the TypeScript ESLint configuration.
  */
-export function typescript(options: OverridesOptions & StylisticOptions & TypeScriptParserOptions = {}): ConfigArray {
+export function typescript(options: OverridesOptions & StylisticOptions & TypeScriptErasableSyntaxOnlyOptions & TypeScriptParserOptions = {}): ConfigArray {
   const { stylistic = true, parserOptions = {}, overrides = {} } = options;
 
   return tseslint.config(

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,15 @@ export interface TypeScriptParserOptions {
   parserOptions?: TSESLint.FlatConfig.ParserOptions;
 }
 
+export interface TypeScriptErasableSyntaxOnlyOptions {
+  /**
+   * Indicates whether the erasable syntax only rules should be enabled or not.
+   *
+   * @default false
+   */
+  enableErasableSyntaxOnly?: boolean;
+}
+
 /**
  * Options for configuring Angular-specific linting rules.
  */
@@ -207,7 +216,7 @@ export interface CreateConfigOptions {
    *
    * @default auto-detected
    */
-  typescript?: boolean | (OverridesOptions & TypeScriptParserOptions);
+  typescript?: boolean | (OverridesOptions & TypeScriptErasableSyntaxOnlyOptions & TypeScriptParserOptions);
 
   /**
    * Enable stylistic rules.


### PR DESCRIPTION
closes #43 